### PR TITLE
Update IRPF 2024 to 1.2

### DIFF
--- a/br.gov.fazenda.receita.irpf2024.metainfo.xml
+++ b/br.gov.fazenda.receita.irpf2024.metainfo.xml
@@ -27,6 +27,9 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.2" date="2024-06-01">
+      <description></description>
+    </release>
     <release version="1.1" date="2024-03-20"/>
     <release version="1.0" date="2024-03-12"/>
   </releases>

--- a/br.gov.fazenda.receita.irpf2024.yaml
+++ b/br.gov.fazenda.receita.irpf2024.yaml
@@ -89,9 +89,9 @@ modules:
         path: icons/icon-256.png
       - type: extra-data
         filename: irpf.zip
-        url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/arquivos/IRPF2024-1.1.zip
-        sha256: e2a57b5eddb3e64160593841d852bb385018dc74d60363c2dbcb531a4e2b8307
-        size: 50379578
+        url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/arquivos/IRPF2024-1.2.zip
+        sha256: 364ee513c2bff3ec38205db350ef72e3257a0791562027fbfd910fe590f8bc10
+        size: 50391503
         x-checker-data:
           type: html
           url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/latest.xml

--- a/generated-sources.yaml
+++ b/generated-sources.yaml
@@ -123,6 +123,17 @@
       url-template: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/MSGS__$version.zip
 
   - type: extra-data
+    filename: MUNCL.zip
+    url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/MUNCL__20240601_20240601093248.zip
+    size: 4331
+    sha256: 7eb6024abcad6d9c3b22f561eb8839d33f0d2e8af9e15f19d9fe102169acc974
+    x-checker-data:
+      type: html
+      url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/latest.xml
+      version-pattern: MUNCL__([\d_]+)\.zip
+      url-template: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/MUNCL__$version.zip
+
+  - type: extra-data
     filename: NATOC.zip
     url: https://downloadirpf.receita.fazenda.gov.br/irpf/2024/irpf/update/NATOC__20221227_20230308072724.zip
     size: 1071


### PR DESCRIPTION
This PR updates to version 1.2, and also:

- Update `irpf-tools-flatpak` submodule 
- Regenerate `generated-sources.yaml`