### PR TITLE
Remove libgnome hack

### DIFF
--- a/br.gov.fazenda.receita.irpf2024.yaml
+++ b/br.gov.fazenda.receita.irpf2024.yaml
@@ -27,14 +27,6 @@ modules:
     build-commands:
       - /usr/lib/sdk/openjdk11/install.sh
 
-  - name: libgnome-stubs
-    no-autogen: true
-    subdir: libgnome-stubs
-    sources:
-      - type: git
-        url: https://github.com/guihkx/irpf-tools-flatpak.git
-        commit: 984b79398697d138ff8dcce1ff0be44b8d9bb94b
-
   - name: irpf2024
     buildsystem: simple
     build-commands:
@@ -43,7 +35,7 @@ modules:
       - install -Dm644 -t /app/share/applications $FLATPAK_ID.desktop
       - install -Dm644 icon-256.png /app/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
       - install -Dm644 -t /app/share/metainfo $FLATPAK_ID.metainfo.xml
-      - ln -s /usr/bin/xdg-open /app/bin/firefox # Fixes the clickable link on the "About" window.
+      - ln -s /usr/bin/xdg-open /app/bin/firefox # Fixes Single Sign-On (SSO).
     sources:
       - type: script
         dest-filename: apply_extra
@@ -68,20 +60,7 @@ modules:
       - type: script
         dest-filename: irpf2024
         commands:
-          # Briefly explaining the script:
-          #
-          # * -Djdk.gtk.version=2: We use this to "trick" the JRE into lading GTK 2 libraries (which we don't provide), which will
-          #                        fail and make the JRE rely on our libgnome stubs instead (see the 'tools/libgnome-stubs' directory).
-          # * _JAVA_OPTIONS: This env var has to be modified to remove any references to the option above, otherwise the trick we
-          #                  apply above will fail, and will break the single sign-on feature provided by the app.
-          - |
-            unsupported_java_option='-Djdk\.gtk\.version=[[:digit:]]'
-            if [[ "${_JAVA_OPTIONS}" =~ ${unsupported_java_option} ]]
-            then
-              echo "${0}: WARNING: Removing unsupported option '${BASH_REMATCH[0]}' from \$_JAVA_OPTIONS" >&2
-              export _JAVA_OPTIONS="${_JAVA_OPTIONS//${unsupported_java_option}/}"
-            fi
-            exec java -Djdk.gtk.version=2 -jar /app/extra/share/irpf.jar $@
+          - exec java -jar /app/extra/share/irpf.jar $@
       - type: file
         path: br.gov.fazenda.receita.irpf2024.metainfo.xml
       - type: file


### PR DESCRIPTION
Before the 1.2 release, this hack was required to enable opening URLs in the web browser, a crucial functionality needed by single sign-on (SSO).