### PR TITLE
Set working directory to `irpf.jar` location in wrapper script

### DIFF
--- a/br.gov.fazenda.receita.irpf2024.yaml
+++ b/br.gov.fazenda.receita.irpf2024.yaml
@@ -61,7 +61,7 @@ modules:
       - type: script
         dest-filename: irpf2024
         commands:
-          - exec java -jar /app/extra/share/irpf.jar $@
+          - cd /app/extra/share && exec java -jar irpf.jar $@
       - type: file
         path: br.gov.fazenda.receita.irpf2024.metainfo.xml
       - type: file


### PR DESCRIPTION
This fixed a bug in IRPF 2026 that would otherwise prevent us from visualizing or printing the tax receipt.

See: https://github.com/flathub/br.gov.fazenda.receita.irpf2026/pull/9

The bug doesn't affect this edition (at least currently), but this is a rather harmless change that I believe it's worth backporting.